### PR TITLE
GHC 927 Upgrade

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+packages:
+  .
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,97 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1690933134,
+        "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "59cf3f1447cfc75087e7273b04b31e689a8599fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "haskell-flake": {
+      "locked": {
+        "lastModified": 1691763544,
+        "narHash": "sha256-QQsSI5VXm0bBijeGSXXNf4fyw76/XmN67NGbmTCx71s=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "f16e7ac05b1f22b66ef05b7fcc8a96281bb2b749",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1689078114,
+        "narHash": "sha256-osG8BrX5RpKJ7wH+vI6auOU+ctvNOblT4XXCgknK47c=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b6cc7ff8fee93789bc871a267ab876c3fca042cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1690881714,
+        "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e1960bc196baf6881340d53dccb203a951745a2",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "haskell-flake": "haskell-flake",
+        "nixpkgs": "nixpkgs",
+        "word24": "word24"
+      }
+    },
+    "word24": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647587255,
+        "narHash": "sha256-S37S10sJ45BulvpqJzlhX/J4hY7cW5jLM9nP4xAftac=",
+        "owner": "winterland1989",
+        "repo": "word24",
+        "rev": "445f791e35ddc8098f05879dbcd07c41b115cb39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "winterland1989",
+        "repo": "word24",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    haskell-flake.url = "github:srid/haskell-flake";
+
+    word24.url = "github:winterland1989/word24";
+    word24.flake = false;
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, ... }: {
+      systems = nixpkgs.lib.systems.flakeExposed;
+      imports = [
+        inputs.haskell-flake.flakeModule
+      ];
+      perSystem = { self', pkgs, lib, config, ... }: {
+        haskellProjects.default = {
+          projectFlakeName = "mysql-haskell";
+          basePackages = pkgs.haskell.packages.ghc927;
+
+          packages = {
+            word24.source = inputs.word24;
+          };
+
+          settings = {
+            word24 = {
+              check = false;
+              broken = false;
+              jailbreak = true;
+            };
+            binary-parsers = {
+              broken = false;
+              jailbreak = true;
+            };
+            wire-streams = {
+              jailbreak = true;
+            };
+          };
+
+          autoWire = [ "packages" "checks" "devShells" "apps"];
+        };
+      };
+    });
+}

--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -33,26 +33,26 @@ library
                     ,   Database.MySQL.BinLogProtocol.BinLogMeta
                     ,   Database.MySQL.Connection
     other-modules:      Database.MySQL.Query
-    build-depends:      base          >= 4.7 && < 5
-                    ,   monad-loops   == 0.4.*
-                    ,   network       >= 2.3 && < 4.0
-                    ,   io-streams    >= 1.2 && < 2.0
-                    ,   tcp-streams   >= 1.0 && < 1.1
-                    ,   wire-streams  >= 0.1
-                    ,   binary        >= 0.8.3
+    build-depends:      base < 5
+                    ,   monad-loops
+                    ,   network
+                    ,   io-streams
+                    ,   tcp-streams
+                    ,   wire-streams
+                    ,   binary
                     ,   binary-ieee754
-                    ,   binary-parsers >= 0.2.1
-                    ,   bytestring    >= 0.10.2.0
-                    ,   text          >= 1.1 && < 1.3
-                    ,   cryptonite    == 0.*
-                    ,   memory        >= 0.14.4 && < 0.16
-                    ,   time          >= 1.5.0
-                    ,   scientific    == 0.3.*
-                    ,   bytestring-lexing == 0.5.*
-                    ,   blaze-textual     == 0.2.*
-                    ,   word24            >= 1.0 && <= 3.0
-                    ,   tls           >= 1.3.5 && < 1.6
-                    ,   vector        >= 0.8
+                    ,   binary-parsers
+                    ,   bytestring
+                    ,   text
+                    ,   cryptonite
+                    ,   memory
+                    ,   time
+                    ,   scientific
+                    ,   bytestring-lexing
+                    ,   blaze-textual
+                    ,   word24
+                    ,   tls
+                    ,   vector
 
     default-language:    Haskell2010
     default-extensions:     DeriveDataTypeable
@@ -75,7 +75,7 @@ test-suite test
     build-depends:  mysql-haskell
                   , base
                   , bytestring
-                  , tasty >= 0.11 && < 2.0
+                  , tasty
                   , tasty-hunit
                   , text
                   , io-streams


### PR DESCRIPTION
This PR enables it to be built with GHC 9.2.7 compiler and nix package set.

Changes include:-

1. New flake based nix build system.
2. direnv support for easier development shell.
3. Enables building with GHC 9.2.7 and related package set.
4. Can be used as a flake input in other projects now.