### PR TITLE
fixed 1.36 to 1.35999 conversion

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for mysql-haskell
 
+## 0.8.4.3 -- 2024-04-02
+
+* fixed Double 1.36 to 1.35999 conversion 
+
 ## 0.8.4.2 -- 2019-01-22
 
 * Fix [stackage#4312](https://github.com/commercialhaskell/stackage/issues/4312): Relax `network` bounds.

--- a/mysql-haskell.cabal
+++ b/mysql-haskell.cabal
@@ -1,5 +1,5 @@
 name:                mysql-haskell
-version:             0.8.4.2
+version:             0.8.4.3
 synopsis:            pure haskell MySQL driver
 description:         pure haskell MySQL driver
 license:             BSD3


### PR DESCRIPTION
Issue: We noticed few `Double` digits, while being fetched from DB, were getting `subtracted` by the least significant precision bit of Double. For example, `1.36` was being converted to `1.3599999999999999` and `1.86` to `1.8599999999999999`

where exactly was it happening: `readDecimal` coming from [`Data.ByteString.Lex.Fractional`](https://hackage.haskell.org/package/bytestring-lexing-0.5.0.11/docs/Data-ByteString-Lex-Fractional.html) had this issue.  They were adding `whole digit` and `decimal digit` which was leading to the issue.

Solution: updated the logic to `(base * whole digit + decimalpart) / base` where base is precision.